### PR TITLE
Add workflow for feature flags project board

### DIFF
--- a/workflows/flags-project-board.yml
+++ b/workflows/flags-project-board.yml
@@ -73,7 +73,7 @@ jobs:
                       });
                       
                       core.setOutput('node_id', pr.node_id);
-                      core.setOutput('is_draft', pr.draft);
+                      core.setOutput('is_draft', pr.draft); // Outputs are always strings.
 
             - name: Determine PR status and desired project status
               id: check
@@ -93,10 +93,11 @@ jobs:
                       let isDraft;
                       let nodeId;
                       
+                      // Convert is_draft to boolean once at the start
                       if (context.eventName === 'pull_request') {
                           // Handle direct PR event
                           pr = context.payload.pull_request;
-                          isDraft = pr.draft;
+                          isDraft = pr.draft;  // pr.draft is already a boolean from the GitHub API
                           nodeId = pr.node_id;
                       } else if (context.eventName === 'workflow_dispatch') {
                           // Handle manual dispatch
@@ -107,7 +108,7 @@ jobs:
                           });
                           pr = prResponse.data;
                           nodeId = steps.get-pr.outputs.node_id;
-                          isDraft = steps.get-pr.outputs.is_draft === 'true';
+                          isDraft = steps.get-pr.outputs.is_draft === 'true';  // Convert string output to boolean
                       } else if (context.eventName === 'workflow_call') {
                           // Handle workflow call
                           const query = `
@@ -144,7 +145,7 @@ jobs:
                           
                           pr = prResponse.data;
                           nodeId = context.payload.inputs.pr_node_id;
-                          isDraft = context.payload.inputs.is_draft === 'true';
+                          isDraft = context.payload.inputs.is_draft;  // Boolean from the calling workflow's inputs
                       } else {
                           throw new Error(`Unsupported event type: ${context.eventName}`);
                       }


### PR DESCRIPTION
This adds a workflow specifically for the Feature Flags team to manage its Project Board. It supports the following:

1. When a PR is assigned a reviewer AND the reviewer is a member of @PostHog/team-feature-flags (or is the team), this adds the PR to the "In Review" column of the feature flags project board: https://github.com/orgs/PostHog/projects/112/views/2
2. If the PR is converted to draft (or was originally in draft), it gets moved to the "In Progress" column.
3. If a draft PR is marked "Ready to review" (and the reviewers are in the feature flags team or the reviewer is the team), then it gets moved back to the "In Review" column.

Unfortunately, a workflow cannot respond to events in other workflows. So we'll need to add the following workflow to each repository we care about:

```yml
name: Call Feature Flags Project Workflow

on:
    pull_request:
        types: [opened, ready_for_review, review_requested, synchronize, converted_to_draft, reopened]

jobs:
    call-flags-project:
        uses: PostHog/.github/.github/workflows/flags-project-board.yml@main
        with:
            pr_number: ${{ github.event.pull_request.number }}
            pr_node_id: ${{ github.event.pull_request.node_id }}
            is_draft: ${{ github.event.pull_request.draft }}
        secrets: inherit
```

I plan to make this workflow even more generic so other teams can use it.

The workflows require GraphQL IDs for project boards which is not trivial to get. Here are the queries I ran using the `gh` command line tool:

__To get the Project Node Id using the numeric project id (`112`)__

```bash
gh api graphql -f query='
  query {
    organization(login: "PostHog") {
      projectV2(number: 112) {
        id
      }
    }
  }
'
```

__To get the IDs of the columns using the project node id from the previous command__

```bash
gh api graphql -f query='
  query {
    node(id: "PVT_kwDOAgyiKM4A7GJu") {
      ... on ProjectV2 {
        fields(first: 30) {
          nodes {
            ... on ProjectV2SingleSelectField {
              id
              name
              options {
                id
                name
              }
            }
            ... on ProjectV2FieldCommon {
              id
              name
            }
          }
        }
      }
    }
  }
'
```

Once this is merged, I'll try adding the calling workflow to `posthog/posthog` and hope it all works! I've tested this in an org I own.