### PR TITLE
Migrate from PAT to GitHub App authentication

### DIFF
--- a/.github/workflows/flags-project-board.yml
+++ b/.github/workflows/flags-project-board.yml
@@ -9,11 +9,12 @@
 # When changes are requested on a PR review, the workflow will:
 # - Set the status of the PR to 'In Progress'
 #
-# Required permissions:
-# - POSTHOG_PROJECT_BOT_TOKEN with:
-#   - repo scope (for PR operations)
-#   - project scope (for project board operations)
-#   - read:org scope (for team membership checks)
+# Required GitHub App permissions:
+# - PROJECT_BOARD_BOT_APP_ID and PROJECT_BOARD_BOT_PRIVATE_KEY secrets
+# - App permissions needed:
+#   - Repository: Pull requests (read)
+#   - Organization: Projects (read & write)
+#   - Organization: Members (read)
 
 name: Add PR to Feature Flags Project
 
@@ -66,12 +67,19 @@ jobs:
         # This is a not well-documented special case.
         if: github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' || github.event_name == 'pull_request_review'
         steps:
+            - name: Generate GitHub App Token
+              id: app-token
+              uses: actions/create-github-app-token@v1
+              with:
+                  app-id: ${{ secrets.PROJECT_BOARD_BOT_APP_ID }}
+                  private-key: ${{ secrets.PROJECT_BOARD_BOT_PRIVATE_KEY }}
+                  owner: ${{ env.ORG_NAME }}
             - name: Get PR Node ID for workflow_dispatch
               id: get-pr
               if: github.event_name == 'workflow_dispatch'
               uses: actions/github-script@v6
               with:
-                  github-token: ${{ secrets.POSTHOG_PROJECT_BOT_TOKEN }}
+                  github-token: ${{ steps.app-token.outputs.token }}
                   script: |
                       const prNumber = ${{ github.event.inputs.pr_number }};
                       const repo = '${{ github.event.inputs.repository }}';
@@ -100,7 +108,7 @@ jobs:
                   IS_DRAFT: ${{ inputs.is_draft }}
                   PR_NUMBER: ${{ inputs.pr_number }}
               with:
-                  github-token: ${{ secrets.POSTHOG_PROJECT_BOT_TOKEN }}
+                  github-token: ${{ steps.app-token.outputs.token }}
                   script: |
                       // Debug logging
                       core.info('Event type: ' + context.eventName);
@@ -251,7 +259,7 @@ jobs:
                   PR_NODE_ID: ${{ steps.check.outputs.pr_node_id }}
                   STATUS_OPTION_ID: ${{ steps.check.outputs.status_option_id }}
               with:
-                  github-token: ${{ secrets.POSTHOG_PROJECT_BOT_TOKEN }}
+                  github-token: ${{ steps.app-token.outputs.token }}
                   script: |
                       const projectId = process.env.PROJECT_V2_ID;
                       const fieldId = process.env.STATUS_FIELD_ID;


### PR DESCRIPTION
Replace `POSTHOG_PROJECT_BOT_TOKEN` personal access token with GitHub App authentication using `PROJECT_BOARD_BOT_APP_ID` and `PROJECT_BOARD_BOT_PRIVATE_KEY`.