### PR TITLE
fix: skip project board workflow for fork PRs

### DIFF
--- a/.github/workflows/flags-project-board.yml
+++ b/.github/workflows/flags-project-board.yml
@@ -69,7 +69,7 @@ jobs:
         # the github.event_name is supposed to be `workflow_call`, but because this workflow lives in the special `.github` repository,
         # it preserves the original event name (e.g. pull_request).
         # This is a not well-documented special case.
-        if: github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' || github.event_name == 'pull_request_review'
+        if: (github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' || github.event_name == 'pull_request_review') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         steps:
             - name: Generate GitHub App Token
               id: app-token


### PR DESCRIPTION
## Problem

The `flags-project-board.yml` workflow runs on all `pull_request` events, including PRs from forks. Fork PRs don't have access to organization secrets (`PROJECT_BOARD_BOT_APP_ID`, `PROJECT_BOARD_BOT_PRIVATE_KEY`), causing the workflow to fail and blocking contributor CI.

**Example failure:** https://github.com/PostHog/posthog-python/actions/runs/23738060355/job/69149062217?pr=467

## Changes

Added a condition to the `add-to-project-board` job to skip execution when the PR comes from a fork:

```
github.event.pull_request.head.repo.full_name == github.repository
```

This check only applies to `pull_request` events — `workflow_dispatch` and `pull_request_review` events are unaffected.