### PR TITLE
feat: add reusable resolve-outdated-bot-comments workflow

### DIFF
--- a/.github/workflows/resolve-outdated-bot-comments.yml
+++ b/.github/workflows/resolve-outdated-bot-comments.yml
@@ -1,0 +1,104 @@
+# Resolves outdated, single-comment review threads left by bots so they
+# don't clutter the PR review UI after the author pushes a fix.
+#
+# Required GitHub App permissions:
+#   - Pull requests: read & write (to resolve review threads)
+#
+# Secrets (must be available to the calling repo):
+#   - app_id / private_key for a GitHub App with the permissions above
+
+name: Resolve outdated bot comments
+
+on:
+    workflow_call:
+        inputs:
+            bots:
+                description: >-
+                    Space-separated list of bot usernames whose outdated
+                    single-comment review threads should be auto-resolved.
+                required: false
+                type: string
+                default: >-
+                    copilot-pull-request-reviewer greptile-apps
+                    chatgpt-codex-connector graphite-app cursor claude
+                    claude-code-action claude-review
+        secrets:
+            app_id:
+                description: GitHub App ID for generating a token
+                required: true
+            private_key:
+                description: GitHub App private key
+                required: true
+
+jobs:
+    resolve-outdated:
+        name: Resolve outdated bot review comments
+        runs-on: ubuntu-24.04
+        timeout-minutes: 5
+
+        steps:
+            - name: Get app token
+              id: app-token
+              uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+              with:
+                  app-id: ${{ secrets.app_id }}
+                  private-key: ${{ secrets.private_key }}
+
+            - name: Resolve outdated bot threads
+              env:
+                  GH_TOKEN: ${{ steps.app-token.outputs.token }}
+                  PR_NUMBER: ${{ github.event.pull_request.number }}
+                  REPO: ${{ github.repository }}
+                  BOTS: ${{ inputs.bots }}
+              run: |
+                  OWNER="${REPO%/*}"
+                  REPO_NAME="${REPO#*/}"
+
+                  THREADS=$(gh api graphql -f query='
+                    query($owner: String!, $repo: String!, $pr: Int!) {
+                      repository(owner: $owner, name: $repo) {
+                        pullRequest(number: $pr) {
+                          reviewThreads(first: 100) {
+                            pageInfo { hasNextPage }
+                            nodes {
+                              id
+                              isOutdated
+                              isResolved
+                              comments(first: 2) {
+                                totalCount
+                                nodes {
+                                  author { login }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }' -f owner="$OWNER" -f repo="$REPO_NAME" -F pr="$PR_NUMBER")
+
+                  HAS_NEXT=$(echo "$THREADS" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage')
+                  if [ "$HAS_NEXT" = "true" ]; then
+                    echo "WARNING: more than 100 review threads found; some outdated bot threads may not be resolved"
+                  fi
+
+                  THREAD_IDS=$(echo "$THREADS" | jq -r --arg bots "$BOTS" '
+                    .data.repository.pullRequest.reviewThreads.nodes[]
+                    | select(.isOutdated == true and .isResolved == false and .comments.totalCount == 1)
+                    | select(.comments.nodes[0].author.login as $author | ($bots | split(" ") | any(. == $author)))
+                    | .id
+                  ')
+
+                  if [ -z "$THREAD_IDS" ]; then
+                    echo "No outdated bot threads to resolve"
+                    exit 0
+                  fi
+
+                  echo "$THREAD_IDS" | while read -r thread_id; do
+                    echo "Resolving thread $thread_id"
+                    gh api graphql -f query='
+                      mutation($id: ID!) {
+                        resolveReviewThread(input: { threadId: $id }) {
+                          thread { isResolved }
+                        }
+                      }' -f id="$thread_id"
+                  done


### PR DESCRIPTION
## Summary

- Add reusable workflow for auto-resolving outdated bot review comments on PRs
- Triggered via `workflow_call` with configurable `bots` list input and GitHub App secrets
- Extracted from [PostHog/posthog's existing workflow](https://github.com/PostHog/posthog/blob/master/.github/workflows/pr-resolve-outdated-bot-comments.yml) so other repos can adopt it

## How to use

```yaml
jobs:
  resolve:
    uses: PostHog/.github/.github/workflows/resolve-outdated-bot-comments.yml@main
    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
    secrets:
      app_id: ${{ secrets.GH_APP_POSTHOG_REVIEW_COMMENT_RESOLVER_APP_ID }}
      private_key: ${{ secrets.GH_APP_POSTHOG_REVIEW_COMMENT_RESOLVER_PRIVATE_KEY }}
```

Override the default bot list with the `bots` input:

```yaml
    with:
      bots: "copilot-pull-request-reviewer cursor claude"
```

## Test plan

- [ ] Merge this, then open PostHog/posthog PR to switch the caller
- [ ] Push to a PR with outdated bot comments and verify threads get resolved