### PR TITLE
chore: pin github actions to commit shas

### DIFF
--- a/.github/workflows/audit-actions.yml
+++ b/.github/workflows/audit-actions.yml
@@ -12,7 +12,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
             - name: Ensure SHA pinned actions
               uses: zgosalvez/github-actions-ensure-sha-pinned-actions@cc9ffdc62fadb9f83b46dd0979d9ad50408cc6a6 # v5.0.2
               with:

--- a/.github/workflows/changeset-hygiene.yml
+++ b/.github/workflows/changeset-hygiene.yml
@@ -19,13 +19,13 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout caller repository
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   ref: ${{ github.event.pull_request.head.sha }}
                   fetch-depth: 0
 
             - name: Checkout PostHog/.github (for the script)
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   repository: PostHog/.github
                   ref: ${{ inputs.script-ref }}
@@ -35,7 +35,7 @@ jobs:
               uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # pin v4.2.0
 
             - name: Setup Node
-              uses: actions/setup-node@v6
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
                   node-version: '22'
 
@@ -46,7 +46,7 @@ jobs:
               run: node _shared/.github/scripts/check-changeset-coverage.mjs >> "$GITHUB_OUTPUT"
 
             - name: Upsert or delete sticky PR comment
-              uses: actions/github-script@v7
+              uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
               env:
                   COMMENT_BODY: ${{ steps.hygiene.outputs.body }}
               with:

--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -22,7 +22,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
             # exclude all directories already scanned by other jobs
             - name: Run Semgrep

--- a/.github/workflows/flags-project-board.yml
+++ b/.github/workflows/flags-project-board.yml
@@ -73,7 +73,7 @@ jobs:
         steps:
             - name: Generate GitHub App Token
               id: app-token
-              uses: actions/create-github-app-token@v3
+              uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
               with:
                   app-id: ${{ secrets.PROJECT_BOARD_BOT_APP_ID }}
                   private-key: ${{ secrets.PROJECT_BOARD_BOT_PRIVATE_KEY }}
@@ -81,7 +81,7 @@ jobs:
             - name: Get PR Node ID for workflow_dispatch
               id: get-pr
               if: github.event_name == 'workflow_dispatch'
-              uses: actions/github-script@v8
+              uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
               env:
                   PR_NUMBER: ${{ github.event.inputs.pr_number }}
                   REPO: ${{ github.event.inputs.repository }}
@@ -105,7 +105,7 @@ jobs:
 
             - name: Determine PR status and matching boards
               id: check
-              uses: actions/github-script@v8
+              uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
               env:
                   ORG_NAME: '${{ env.ORG_NAME }}'
                   PR_NODE_ID: ${{ inputs.pr_node_id }}
@@ -257,7 +257,7 @@ jobs:
                       core.setOutput('pr_node_id', nodeId);
             - name: Update Project Boards
               if: steps.check.outputs.has_matches == 'true'
-              uses: actions/github-script@v8
+              uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
               env:
                   MATCHING_BOARDS: '${{ steps.check.outputs.matching_boards }}'
                   PR_NODE_ID: ${{ steps.check.outputs.pr_node_id }}

--- a/.github/workflows/notify-approval-needed.yml
+++ b/.github/workflows/notify-approval-needed.yml
@@ -26,7 +26,7 @@ jobs:
       slack_ts: ${{ steps.notify.outputs.ts }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -125,7 +125,7 @@ jobs:
 
       - name: Send Slack failure event to PostHog
         if: ${{ steps.notify.outcome == 'failure' }}
-        uses: PostHog/posthog-github-action@v1.1.1
+        uses: PostHog/posthog-github-action@eea1405eeb2d1d2259f0ee0b44d7b152869e6840 # v1.1.1
         with:
           posthog-token: "${{ secrets.posthog_project_api_key }}"
           event: "sdk-slack-notification-failure"

--- a/.github/workflows/semgrep-tests.yml
+++ b/.github/workflows/semgrep-tests.yml
@@ -18,7 +18,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
             - name: Test custom Semgrep rules
               run: |

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -19,10 +19,10 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
             - name: Checkout .github repo (for custom semgrep rules)
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   repository: PostHog/.github
                   path: dotgithub-repo


### PR DESCRIPTION
Pins actions in .github/workflows to commit SHAs via pinact. Generated by multi-gitter.