### PR TITLE
ci(security): pin semgrep image to 1.163.0

### DIFF
--- a/.github/workflows/semgrep-tests.yml
+++ b/.github/workflows/semgrep-tests.yml
@@ -14,7 +14,7 @@ jobs:
     semgrep-test-rules:
         runs-on: ubuntu-latest
         container:
-            image: semgrep/semgrep
+            image: semgrep/semgrep:1.163.0@sha256:7cad2bc2d1e44f87f0bf4be6d1fa23aa90fb72015bebc89fb91385d813987a03
 
         steps:
             - name: Checkout

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -15,7 +15,7 @@ jobs:
     semgrep:
         runs-on: ubuntu-latest
         container:
-            image: semgrep/semgrep
+            image: semgrep/semgrep:1.163.0@sha256:7cad2bc2d1e44f87f0bf4be6d1fa23aa90fb72015bebc89fb91385d813987a03
 
         steps:
             - name: Checkout


### PR DESCRIPTION
We were using an unpinned image.