### PR TITLE
chore: add reusable semantic PR title workflow

### DIFF
--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -3,15 +3,14 @@ name: Semantic PR title
 on:
     workflow_call:
 
-permissions:
-    contents: read
-    pull-requests: read
-
 jobs:
     lint-pr:
         name: Validate PR title against Conventional Commits
-        runs-on: ubuntu-24.04
+        runs-on: ubuntu-latest
         timeout-minutes: 5
+        permissions:
+            contents: read
+            pull-requests: read
         steps:
             - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
               env:

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -1,0 +1,18 @@
+name: Semantic PR title
+
+on:
+    workflow_call:
+
+permissions:
+    contents: read
+    pull-requests: read
+
+jobs:
+    lint-pr:
+        name: Validate PR title against Conventional Commits
+        runs-on: ubuntu-24.04
+        timeout-minutes: 5
+        steps:
+            - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Adds a reusable workflow for validating PR titles against Conventional Commits.

SDK repos can call this shared workflow instead of each repo directly invoking `amannn/action-semantic-pull-request`, keeping the underlying third-party action pin and configuration centralized in `PostHog/.github`.

## Testing

- Parsed the new workflow YAML locally with PyYAML.
