### PR TITLE
chore: Load team-board mapping from a runtime config file

### DIFF
--- a/.github/flags-boards.json
+++ b/.github/flags-boards.json
@@ -1,0 +1,4 @@
+{
+    "team-feature-flags": "PVT_kwDOA5iQ-M4AroCF",
+    "clickhouse": "PVT_kwDOA5iQ-M4ARqEU"
+}

--- a/.github/workflows/flags-project-board.yml
+++ b/.github/workflows/flags-project-board.yml
@@ -44,8 +44,6 @@ on:
                 description: 'Whether the pull request is in draft mode'
                 required: true
                 type: boolean
-    pull_request_review:
-        types: [submitted]
     workflow_dispatch:
         inputs:
             pr_number:

--- a/.github/workflows/flags-project-board.yml
+++ b/.github/workflows/flags-project-board.yml
@@ -28,7 +28,6 @@ env:
     ORG_NAME: PostHog
     TEAM_BOARDS: |
         team-feature-flags=PVT_kwDOA5iQ-M4AroCF
-        team-flags-platform=PVT_kwDOA5iQ-M4BPB59
         clickhouse=PVT_kwDOA5iQ-M4ARqEU
 
 on:

--- a/.github/workflows/flags-project-board.yml
+++ b/.github/workflows/flags-project-board.yml
@@ -1,5 +1,7 @@
 # This workflow manages pull requests on project boards for the Feature Flags teams.
-# It uses a team-to-board mapping (TEAM_BOARDS) to route PRs to the correct boards.
+# It reads a team-to-board mapping from .github/flags-boards.json on the default
+# branch to route PRs to the correct boards. The mapping is loaded at runtime, so
+# editing the board list does not require callers to re-pin this workflow's SHA.
 # When a member of a mapped team is added as a reviewer to a PR, the workflow will:
 # - Add the PR to that team's project board
 # - Set the status of the PR to 'In Review'
@@ -14,21 +16,15 @@
 # Required GitHub App permissions:
 # - PROJECT_BOARD_BOT_APP_ID and PROJECT_BOARD_BOT_PRIVATE_KEY secrets
 # - App permissions needed:
+#   - Repository: Contents (read)        # to read .github/flags-boards.json
 #   - Repository: Pull requests (read)
 #   - Organization: Projects (read & write)
 #   - Organization: Members (read)
 
 name: Add PR to Feature Flags Project
 
-# Each entry maps a GitHub team slug to a project board ID. When a member of the
-# team is requested as a reviewer, the PR is added to that team's board. The
-# workflow discovers the Status field and its "In Review" / "In Progress" options
-# by name at runtime.
 env:
     ORG_NAME: PostHog
-    TEAM_BOARDS: |
-        team-feature-flags=PVT_kwDOA5iQ-M4AroCF
-        clickhouse=PVT_kwDOA5iQ-M4ARqEU
 
 on:
     workflow_call:
@@ -117,13 +113,21 @@ jobs:
                   script: |
                       core.info('Event type: ' + context.eventName);
 
-                      const teamBoardConfig = process.env.TEAM_BOARDS
-                          .trim().split('\n')
-                          .filter(line => line.trim() && !line.startsWith('#'))
-                          .map(line => {
-                              const [teamSlug, projectId] = line.trim().split('=');
-                              return { team_slug: teamSlug, project_v2_id: projectId };
-                          });
+                      // Load the team-to-board mapping from .github/flags-boards.json on the
+                      // default branch of PostHog/.github. Reading it at runtime (rather than
+                      // baking it into this file) means editing the board list does not change
+                      // this workflow's SHA, so callers never have to re-pin. The github context
+                      // points at the caller in a reusable workflow, so the repo is hardcoded.
+                      const { data: file } = await github.rest.repos.getContent({
+                          owner: process.env.ORG_NAME,
+                          repo: '.github',
+                          path: '.github/flags-boards.json'
+                      });
+                      const mapping = JSON.parse(Buffer.from(file.content, 'base64').toString('utf8'));
+                      const teamBoardConfig = Object.entries(mapping).map(
+                          ([teamSlug, projectId]) => ({ team_slug: teamSlug, project_v2_id: projectId })
+                      );
+                      core.info(`Loaded ${teamBoardConfig.length} team-board mapping(s) from flags-boards.json.`);
 
                       let pr, isDraft, nodeId;
 


### PR DESCRIPTION
## Summary

Move the team-to-board mapping out of `flags-project-board.yml` and into `.github/flags-boards.json`, read at runtime via the Contents API from the default branch.

Today `TEAM_BOARDS` lives in a workflow-level `env:` block. Editing it changes the workflow file, which changes its SHA, and every caller pins this reusable workflow by SHA (`uses: PostHog/.github/.github/workflows/flags-project-board.yml@<sha>`). So a board change forces a re-pin across all ~11 callers. Reading the mapping from a separate file on `main` breaks that coupling: edit the JSON, merge to `main`, and every caller picks it up on the next run without re-pinning.

This also drops the `team-flags-platform` board (#170) by omission, since it's simply absent from the new JSON. PRs now route to a board only when a `team-feature-flags` (#112) or `clickhouse` reviewer is requested.

## Why a config file and not `vars`

For reusable workflows, the `vars` context resolves to the caller's repository, not `.github` ([docs](https://docs.github.com/en/actions/reference/workflows-and-actions/variables)). An org-level `var` can also be silently shadowed by a repo-level one. Neither gives a single source of truth owned by this repo. A version-controlled file read from `main` does, and it keeps the mapping reviewable with history.

## Changes

- New file `.github/flags-boards.json` holds the `{ team-slug: project-board-id }` mapping.
- The "Determine PR status and matching boards" step reads and parses it via `github.rest.repos.getContent` instead of parsing the `TEAM_BOARDS` env string. The repo is hardcoded to `PostHog/.github` because the github context points at the caller in a reusable workflow.
- Adds `Repository: Contents (read)` to the documented required app permissions.

## Notes

`.github/workflows/` is CODEOWNED by @PostHog/team-security, so this needs their review. The actual deletion of the `team-flags-platform` GitHub team should be coordinated separately.