### PR TITLE
chore: add semgrep package manager release-age check

### DIFF
--- a/.github/workflows/semgrep-package-managers.yml
+++ b/.github/workflows/semgrep-package-managers.yml
@@ -1,0 +1,39 @@
+on:
+    pull_request:
+    merge_group:
+
+name: Semgrep Package Managers
+
+permissions:
+    contents: read
+
+env:
+    SEMGREP_ENABLE_VERSION_CHECK: 'false'
+
+jobs:
+    # scans the entire repo for package managers missing a minimum release age / cooldown
+    semgrep-package-managers:
+        runs-on: ubuntu-latest
+        container:
+            image: semgrep/semgrep:1.163.0@sha256:7cad2bc2d1e44f87f0bf4be6d1fa23aa90fb72015bebc89fb91385d813987a03
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  fetch-depth: 1
+
+            - name: Run Semgrep
+              run: |
+                  semgrep \
+                    --config "r/package_managers.renovate.renovate-missing-minimum-release-age.renovate-missing-minimum-release-age" \
+                    --config "r/package_managers.dependabot.dependabot-missing-cooldown.dependabot-missing-cooldown" \
+                    --config "r/package_managers.pnpm.pnpm-missing-minimum-release-age.pnpm-minimum-release-age" \
+                    --config "r/package_managers.yarn.yarn-missing-minimal-age-gate.yarn-missing-minimal-age-gate" \
+                    --config "r/package_managers.bun.bun-missing-minimum-release-age.bun-missing-minimum-release-age" \
+                    --config "r/package_managers.npm.npm-missing-minimum-release-age.npm-missing-minimum-release-age" \
+                    --config "r/package_managers.uv.uv-missing-dependency-cooldown.uv-missing-dependency-cooldown" \
+                    --error \
+                    --metrics=off \
+                    --verbose \
+                    .


### PR DESCRIPTION
Add a separate Semgrep workflow that scans the entire repo for package managers missing a minimum release age / cooldown setting. Uses registry rules and a shallow single-repo checkout so it can run in other repos.

I'll add this as an optional check that runs on every PR in every repo via an org-wide ruleset.