### PR TITLE
chore(devex): use Depot runner for private repos in org-wide semgrep workflows

### DIFF
--- a/.github/workflows/semgrep-package-managers.yml
+++ b/.github/workflows/semgrep-package-managers.yml
@@ -13,7 +13,11 @@ env:
 jobs:
     # scans the entire repo for package managers missing a minimum release age / cooldown
     semgrep-package-managers:
-        runs-on: ubuntu-latest
+        # This workflow runs org-wide as a required workflow. Private/internal repos
+        # get the faster Depot runner; public repos stay on GitHub-hosted ubuntu-latest
+        # (free minutes, and not every public repo has Depot enabled). The repository
+        # context reflects the target repo, so this resolves per-repo automatically.
+        runs-on: ${{ github.event.repository.private && 'depot-ubuntu-latest' || 'ubuntu-latest' }}
         container:
             image: semgrep/semgrep:1.163.0@sha256:7cad2bc2d1e44f87f0bf4be6d1fa23aa90fb72015bebc89fb91385d813987a03
 

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -13,7 +13,11 @@ env:
 jobs:
     # scans GitHub Actions and other repo-wide config
     semgrep:
-        runs-on: ubuntu-latest
+        # This workflow runs org-wide as a required workflow. Private/internal repos
+        # get the faster Depot runner; public repos stay on GitHub-hosted ubuntu-latest
+        # (free minutes, and not every public repo has Depot enabled). The repository
+        # context reflects the target repo, so this resolves per-repo automatically.
+        runs-on: ${{ github.event.repository.private && 'depot-ubuntu-latest' || 'ubuntu-latest' }}
         container:
             image: semgrep/semgrep:1.163.0@sha256:7cad2bc2d1e44f87f0bf4be6d1fa23aa90fb72015bebc89fb91385d813987a03
 


### PR DESCRIPTION
The org-wide semgrep checks run as required workflows, so they currently burn paid GitHub-hosted minutes on `ubuntu-latest` for every private and internal repo. Route those to the faster `depot-ubuntu-latest` runner; public repos stay on `ubuntu-latest` (free minutes).

Covers both org-wide workflows:
- `semgrep-package-managers.yml` — package-manager release-age / cooldown scan
- `semgrep.yml` — GitHub Actions / repo config scan

The runner is chosen from `github.event.repository.private`, which reflects the target repo at run time, so it's automatic and per-repo — no per-repo config. Present on both `pull_request` and `merge_group`; a missing repository object falls back to `ubuntu-latest`.

If a private repo doesn't have Depot enabled, the only effect is the job sits queued waiting for a runner — it doesn't block anything else, and these aren't required status checks, so it won't block merges either. Worth a quick check that Depot is broadly enabled, but low-risk.

Left alone on purpose:
- `semgrep-tests.yml` — runs `semgrep --test .semgrep/`, which only makes sense in this repo (the rules live here), so it's not org-wide.
- `ci-security.yml` — unclear whether it's wired into the org ruleset. If it is, it should get the same change; say the word and it's a one-liner.