### PR TITLE
ci: skip flags project board for Dependabot PRs

### DIFF
--- a/.github/workflows/flags-project-board.yml
+++ b/.github/workflows/flags-project-board.yml
@@ -62,7 +62,11 @@ jobs:
         # the github.event_name is supposed to be `workflow_call`, but because this workflow lives in the special `.github` repository,
         # it preserves the original event name (e.g. pull_request).
         # This is a not well-documented special case.
-        if: (github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' || github.event_name == 'pull_request_review') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        # Dependabot-triggered runs execute in a restricted secret context with no
+        # access to PROJECT_BOARD_BOT_APP_ID / PRIVATE_KEY, so the token step below
+        # hard-fails ("'app-id' must be a non-empty string") on every dependency-bump
+        # PR. Skip them — dependency bumps don't belong on the feature flags board.
+        if: (github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' || github.event_name == 'pull_request_review') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && github.actor != 'dependabot[bot]'
         steps:
             - name: Generate GitHub App Token
               id: app-token


### PR DESCRIPTION
## Problem

The `add-to-project-board` job generates a GitHub App token as its **first, unconditional step**:

```yaml
- name: Generate GitHub App Token
  uses: actions/create-github-app-token@...
  with:
      app-id: ${{ secrets.PROJECT_BOARD_BOT_APP_ID }}
      private-key: ${{ secrets.PROJECT_BOARD_BOT_PRIVATE_KEY }}
```

Dependabot-triggered workflow runs execute in a **restricted secret context** — GitHub deliberately withholds normal Actions/org secrets from Dependabot to limit supply-chain blast radius. So those secrets resolve to empty and the step hard-fails on **every dependency-bump PR**, in **every repo that calls this workflow**:

```
Error: The 'client-id' (or deprecated 'app-id') input must be set to a non-empty string.
Token is not set
```

This has been red on Dependabot PRs since the 2025-09-09 PAT → GitHub App migration.

## Fix

Append `github.actor != 'dependabot[bot]'` to the job condition.

- **Safe:** the board only acts when a Feature Flags team member is requested as a reviewer — which never happens on Dependabot bumps. It's project-management automation, not a test/correctness gate, so nothing is lost.
- **Safer than the alternative:** exposing `PROJECT_BOARD_BOT_APP_ID`/`PRIVATE_KEY` to the Dependabot secret context would also fix it, but would hand an org-write GitHub App key to the untrusted Dependabot context — exactly what GitHub's secret isolation protects against.

## This is already being worked around per-repo

Several repos currently carry this exact `github.actor != 'dependabot[bot]'` guard at the **caller** level, which is what motivated centralizing it here:

- **PostHog/posthog** — already guarded inline
- **PostHog/posthog-private** — already guarded inline
- **PostHog/posthog-python** — https://github.com/PostHog/posthog-python/pull/652 (open)

## ⚠️ Note on propagation

Callers **pin this workflow to a commit SHA** (`@d8b55d05...`), so merging this does **not** auto-fix existing callers — each repo only picks it up when its pin is bumped to the new SHA. After this merges I'll bump the pins on the affected callers (and drop the now-redundant per-repo guards). Repos with live failing Dependabot PRs that still need attention: **posthog-cloud-infra** (2 open), **posthog-ios**, **posthog-js**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
