### PR TITLE
ci: support no-checkout release approval notices

### DIFF
--- a/.github/workflows/notify-approval-needed.yml
+++ b/.github/workflows/notify-approval-needed.yml
@@ -9,6 +9,16 @@ on:
       slack_user_group_id:
         required: true
         type: string
+      tag_pattern:
+        description: "Tag glob used for the compare base."
+        required: false
+        type: string
+        default: "*"
+      tag_sort:
+        description: "Tag sort mode: creatordate or version."
+        required: false
+        type: string
+        default: "creatordate"
     secrets:
       slack_bot_token:
         required: true
@@ -25,32 +35,56 @@ jobs:
     outputs:
       slack_ts: ${{ steps.notify.outputs.ts }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-
       - name: Get info
         id: get-info
         shell: bash
+        env:
+          DEFAULT_BRANCH_FALLBACK: ${{ github.event.repository.default_branch }}
+          REPOSITORY: ${{ github.repository }}
+          TAG_PATTERN: ${{ inputs.tag_pattern }}
+          TAG_SORT: ${{ inputs.tag_sort }}
         run: |
-          # Fetch all tags
-          git fetch --tags --force
+          set -euo pipefail
 
-          # Get the most recent tag (sorted by date, not version)
-          # Note: Use read instead of piping to head to avoid SIGPIPE (exit 141)
-          ALL_TAGS=$(git tag --sort=-creatordate)
-          read -r LATEST_TAG <<< "$ALL_TAGS"
+          repo_url="https://github.com/${REPOSITORY}.git"
+
+          case "$TAG_SORT" in
+            creatordate)
+              sort_arg="--sort=-creatordate"
+              ;;
+            version)
+              sort_arg="--sort=-version:refname"
+              ;;
+            *)
+              echo "::error::tag_sort must be 'creatordate' or 'version'"
+              exit 1
+              ;;
+          esac
+
+          tag_glob="${TAG_PATTERN:-*}"
+          tag_ref_pattern="refs/tags/$tag_glob"
+          LATEST_TAG=$(
+            git ls-remote --tags --refs "$sort_arg" "$repo_url" "$tag_ref_pattern" |
+              awk -F 'refs/tags/' 'NR == 1 { print $2 }'
+          )
 
           if [ -z "$LATEST_TAG" ]; then
-          echo "No tags found, using initial commit"
-          LATEST_TAG=$(git rev-list --max-parents=0 HEAD)
+            echo "No tags found for pattern '$tag_glob', using HEAD"
+            LATEST_TAG="HEAD"
           fi
 
           echo "latest_tag=$LATEST_TAG" >> "$GITHUB_OUTPUT"
 
-          # Get default branch from GitHub API
-          DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@' | tr -d '\n')
+          DEFAULT_BRANCH="${DEFAULT_BRANCH_FALLBACK:-}"
+          if [ -z "$DEFAULT_BRANCH" ]; then
+            DEFAULT_BRANCH=$(
+              git ls-remote --symref "$repo_url" HEAD |
+                awk '/^ref:/ { sub("refs/heads/", "", $2); print $2; exit }'
+            )
+          fi
+          if [ -z "$DEFAULT_BRANCH" ]; then
+            DEFAULT_BRANCH="main"
+          fi
           echo "default_branch=$DEFAULT_BRANCH" >> "$GITHUB_OUTPUT"
 
       - name: Send Slack notification

--- a/.github/workflows/notify-approval-needed.yml
+++ b/.github/workflows/notify-approval-needed.yml
@@ -9,6 +9,11 @@ on:
       slack_user_group_id:
         required: true
         type: string
+      checkout_repository:
+        description: "Checkout the caller repository before building the compare URL."
+        required: false
+        type: boolean
+        default: true
       tag_pattern:
         description: "Tag glob used for the compare base."
         required: false
@@ -35,10 +40,17 @@ jobs:
     outputs:
       slack_ts: ${{ steps.notify.outputs.ts }}
     steps:
+      - name: Checkout repository
+        if: inputs.checkout_repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
       - name: Get info
         id: get-info
         shell: bash
         env:
+          CHECKOUT_REPOSITORY: ${{ inputs.checkout_repository }}
           DEFAULT_BRANCH_FALLBACK: ${{ github.event.repository.default_branch }}
           REPOSITORY: ${{ github.repository }}
           TAG_PATTERN: ${{ inputs.tag_pattern }}
@@ -46,42 +58,51 @@ jobs:
         run: |
           set -euo pipefail
 
-          repo_url="https://github.com/${REPOSITORY}.git"
+          if [ "$CHECKOUT_REPOSITORY" = "true" ]; then
+            # Fetch all tags
+            git fetch --tags --force
 
-          case "$TAG_SORT" in
-            creatordate)
-              sort_arg="--sort=-creatordate"
-              ;;
-            version)
-              sort_arg="--sort=-version:refname"
-              ;;
-            *)
-              echo "::error::tag_sort must be 'creatordate' or 'version'"
+            # Get the most recent tag (sorted by date, not version)
+            # Note: Use read instead of piping to head to avoid SIGPIPE (exit 141)
+            ALL_TAGS=$(git tag --sort=-creatordate)
+            read -r LATEST_TAG <<< "$ALL_TAGS"
+
+            if [ -z "$LATEST_TAG" ]; then
+              echo "No tags found, using initial commit"
+              LATEST_TAG=$(git rev-list --max-parents=0 HEAD)
+            fi
+
+            DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@' | tr -d '\n')
+          else
+            if [ "$TAG_SORT" != "version" ]; then
+              echo "::error::checkout_repository=false requires tag_sort=version"
               exit 1
-              ;;
-          esac
+            fi
 
-          tag_glob="${TAG_PATTERN:-*}"
-          tag_ref_pattern="refs/tags/$tag_glob"
-          LATEST_TAG=$(
-            git ls-remote --tags --refs "$sort_arg" "$repo_url" "$tag_ref_pattern" |
-              awk -F 'refs/tags/' 'NR == 1 { print $2 }'
-          )
+            repo_url="https://github.com/${REPOSITORY}.git"
+            tag_glob="${TAG_PATTERN:-*}"
+            tag_ref_pattern="refs/tags/$tag_glob"
+            LATEST_TAG=$(
+              git ls-remote --tags --refs --sort=-version:refname "$repo_url" "$tag_ref_pattern" |
+                awk -F 'refs/tags/' 'NR == 1 { print $2 }'
+            )
 
-          if [ -z "$LATEST_TAG" ]; then
-            echo "No tags found for pattern '$tag_glob', using HEAD"
-            LATEST_TAG="HEAD"
+            if [ -z "$LATEST_TAG" ]; then
+              echo "No tags found for pattern '$tag_glob', using HEAD"
+              LATEST_TAG="HEAD"
+            fi
+
+            DEFAULT_BRANCH="${DEFAULT_BRANCH_FALLBACK:-}"
+            if [ -z "$DEFAULT_BRANCH" ]; then
+              DEFAULT_BRANCH=$(
+                git ls-remote --symref "$repo_url" HEAD |
+                  awk '/^ref:/ { sub("refs/heads/", "", $2); print $2; exit }'
+              )
+            fi
           fi
 
           echo "latest_tag=$LATEST_TAG" >> "$GITHUB_OUTPUT"
 
-          DEFAULT_BRANCH="${DEFAULT_BRANCH_FALLBACK:-}"
-          if [ -z "$DEFAULT_BRANCH" ]; then
-            DEFAULT_BRANCH=$(
-              git ls-remote --symref "$repo_url" HEAD |
-                awk '/^ref:/ { sub("refs/heads/", "", $2); print $2; exit }'
-            )
-          fi
           if [ -z "$DEFAULT_BRANCH" ]; then
             DEFAULT_BRANCH="main"
           fi


### PR DESCRIPTION
## Summary

- keep the release approval Slack workflow's existing checkout behavior by default
- add an opt-in no-checkout compare URL path for callers with version-sortable tag patterns
- require tag_sort=version when checkout_repository=false, because remote creatordate sorting is not compatible with standalone SDK repos

## Why

PostHog/posthog release-cli approval notification spent 11m29s in checkout because actions/checkout fetched every branch and tag from the monorepo. The Slack notification only needs a compare URL, but other SDK release workflows still rely on the existing checkout-based latest-tag behavior.

## Compatibility

Audited local SDK callers: posthog-ruby, posthog-go, posthog-php, posthog-python, posthog-ios, posthog-rs, posthog-android, posthog-dotnet, posthog-elixir, and posthog-js.

Default behavior remains checkout_repository=true, so existing `@main` and pinned callers keep the old full-checkout tag lookup semantics.

## Test Plan

- actionlint .github/workflows/notify-approval-needed.yml
- python3 YAML parse for .github/workflows/notify-approval-needed.yml
- verified checkout_repository=false with tag_pattern=posthog-cli/v* and tag_sort=version returns posthog-cli/v0.7.20 and master without checkout
- verified checkout_repository=false with tag_sort=creatordate fails loudly
- verified GitHub compare accepts posthog-cli/v0.7.20...master
