### PR TITLE
chore: add markdown-only PR detector workflow

### DIFF
--- a/.github/workflows/detect-markdown-only.yml
+++ b/.github/workflows/detect-markdown-only.yml
@@ -1,0 +1,41 @@
+name: Detect markdown-only changes
+
+on:
+    workflow_call:
+        outputs:
+            markdown_only:
+                description: Whether every changed file in the pull request ends in `.md`.
+                value: ${{ jobs.detect.outputs.markdown_only }}
+
+jobs:
+    detect:
+        name: Detect markdown-only changes
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        permissions:
+            pull-requests: read
+        outputs:
+            markdown_only: ${{ steps.detect.outputs.markdown_only }}
+        steps:
+            - name: Detect markdown-only PR
+              id: detect
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  EVENT_NAME: ${{ github.event_name }}
+                  PR_NUMBER: ${{ github.event.pull_request.number }}
+                  REPOSITORY: ${{ github.repository }}
+              run: |
+                  set -euo pipefail
+
+                  if [ "$EVENT_NAME" != "pull_request" ] || [ -z "$PR_NUMBER" ]; then
+                    echo "markdown_only=false" >> "$GITHUB_OUTPUT"
+                    exit 0
+                  fi
+
+                  markdown_only=$(
+                    gh api --paginate --slurp "repos/$REPOSITORY/pulls/$PR_NUMBER/files?per_page=100" \
+                      | jq -r 'flatten | if length == 0 then "false" else (all(.[]; (.filename | test("\\.md$")) and ((has("previous_filename") | not) or (.previous_filename | test("\\.md$")))) | tostring) end'
+                  )
+
+                  echo "markdown_only=$markdown_only" >> "$GITHUB_OUTPUT"
+                  echo "markdown_only=$markdown_only"


### PR DESCRIPTION
## Problem

Several SDK repositories need required checks to report success for markdown-only PRs without running expensive build/test jobs. Copying the same detector into every repo makes the permissions and behavior harder to keep consistent.

## Changes

Add a reusable `workflow_call` workflow that reports whether every changed pull request file ends in `.md`.

- Uses only `pull-requests: read` permissions.
- Uses the PR files API with pagination.
- Treats non-PR events and empty file lists as `markdown_only=false`.
- For renamed files, requires both the new filename and previous filename to end in `.md`.

## How did you test this code?

- Parsed the workflow YAML locally.
- Ran `git diff --check`.
- Verified the API/JQ expression against a markdown-only PR and a workflow-change PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi was used to factor repeated markdown-only detection logic out of several SDK workflow PRs into one org-level reusable workflow before updating those repos.
