### PR TITLE
chore: declare workflow_call secrets on flags-project-board

### DIFF
--- a/.github/workflows/flags-project-board.yml
+++ b/.github/workflows/flags-project-board.yml
@@ -44,6 +44,16 @@ on:
                 description: 'Whether the pull request is in draft mode'
                 required: true
                 type: boolean
+        # Declared so callers can pass exactly these instead of `secrets: inherit`.
+        # Optional to stay compatible with existing inherit callers and with
+        # restricted contexts (dependabot) where the org secrets are absent.
+        secrets:
+            PROJECT_BOARD_BOT_APP_ID:
+                description: 'GitHub App ID for the project board bot'
+                required: false
+            PROJECT_BOARD_BOT_PRIVATE_KEY:
+                description: 'GitHub App private key for the project board bot'
+                required: false
     workflow_dispatch:
         inputs:
             pr_number:


### PR DESCRIPTION
## Problem

- `flags-project-board.yml` declares no `workflow_call.secrets`, so callers (e.g. `pr-housekeeping.yml` in PostHog/posthog) are forced to use `secrets: inherit`, exposing every repo/org secret to this workflow instead of the two it needs.

## Changes

- Declare `PROJECT_BOARD_BOT_APP_ID` and `PROJECT_BOARD_BOT_PRIVATE_KEY` under `workflow_call.secrets`.
- Marked `required: false`: existing `secrets: inherit` callers keep working unchanged, and dependabot's restricted-secret context (already skipped by the job `if`) doesn't fail validation.
- No behavior change for current callers; enables PostHog/posthog#68964 to pass named secrets and drop its `secrets-inherit` semgrep suppression.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- I (Claude via PostHog Code) verified these are the only two secrets the workflow references, prompted by a Varia review finding on PostHog/posthog#68964.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
