### PR TITLE
fix(ci): exclude new semgrep add-mask audit rule

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -52,6 +52,7 @@ jobs:
                     --exclude-rule dockerfile.security.no-sudo-in-dockerfile.no-sudo-in-dockerfile \
                     --exclude-rule trailofbits.generic.redis-unencrypted-transport.redis-unencrypted-transport \
                     --exclude-rule trailofbits.yaml.docker-compose.port-all-interfaces.port-all-interfaces \
+                    --exclude-rule yaml.github-actions.security.audit.unsafe-add-mask-workflow-command.unsafe-add-mask-workflow-command \
                     --error \
                     --metrics=off \
                     --verbose \


### PR DESCRIPTION
## Problem

- The org-wide `Semgrep / semgrep` required workflow went red across repos around 20:21 UTC.
- Registry packs are fetched live (only the image is pinned), and `p/github-actions` gained `unsafe-add-mask-workflow-command`.
- It fires on every pre-existing `echo "::add-mask::$VAR"` line. In PostHog/posthog that is 7 findings across 5 workflows. Rollout is gradual, so jobs load 807 rules (green) or 809/810 (red), which looked like flake.

## Changes

- One more `--exclude-rule`, alongside the four already there.
- No code fix exists: the rule flags masking itself, since `::stop-commands::` can defeat `add-mask`. Dropping the masking would be strictly worse.

## Testing

Pinned semgrep image against `PostHog/posthog/.github/workflows/`: `p/github-actions` alone gives 7 blocking findings, exit 1. With the exclusion, 0 and exit 0.

Companion fix for the in-repo scanner: PostHog/posthog#73362.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code diagnosed and wrote this. I pointed it at "semgrep is failing across CI".
- Comparing rule counts between passing and failing jobs pinned it to a registry change rather than any repo diff.
- Follow-up worth filing: pin or vendor the registry packs so an upstream rule addition can't red every repo in the org at once.
