### PR TITLE
ci: upgrade changeset hygiene actions to Node 24

### DIFF
--- a/.github/workflows/changeset-hygiene.yml
+++ b/.github/workflows/changeset-hygiene.yml
@@ -32,7 +32,7 @@ jobs:
                   path: _shared
 
             - name: Install pnpm
-              uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # pin v4.2.0
+              uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # pin v6.0.9
 
             - name: Setup Node
               uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -46,7 +46,7 @@ jobs:
               run: node _shared/.github/scripts/check-changeset-coverage.mjs >> "$GITHUB_OUTPUT"
 
             - name: Upsert or delete sticky PR comment
-              uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+              uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
               env:
                   COMMENT_BODY: ${{ steps.hygiene.outputs.body }}
               with:


### PR DESCRIPTION
## Problem

The reusable changeset hygiene workflow still targets Node.js 20 through `pnpm/action-setup` and `actions/github-script`. GitHub now forces these actions onto Node.js 24 and emits deprecation warnings.

## Changes

- Upgrade `pnpm/action-setup` from v4.2.0 to v6.0.9.
- Upgrade `actions/github-script` from v7.1.0 to v9.0.0.
- Keep both actions pinned to immutable commit SHAs.

## Validation

- Confirmed both upgraded actions declare `runs.using: node24`.
- Parsed the workflow as YAML and ran `git diff --check`.
