### PR TITLE
fix(ci): fail incomplete Semgrep scans

### DIFF
--- a/.github/scripts/report-semgrep-results.py
+++ b/.github/scripts/report-semgrep-results.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Turn Semgrep JSON output into GitHub annotations and an accurate summary."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def command_escape(value: object, *, property_value: bool = False) -> str:
+    escaped = str(value).replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+    if property_value:
+        escaped = escaped.replace(":", "%3A").replace(",", "%2C")
+    return escaped
+
+
+def annotation(level: str, message: str, **properties: object) -> None:
+    rendered_properties = ",".join(
+        f"{key}={command_escape(value, property_value=True)}" for key, value in properties.items() if value is not None
+    )
+    separator = " " if rendered_properties else ""
+    print(f"::{level}{separator}{rendered_properties}::{command_escape(message)}")
+
+
+def error_type(error: dict[str, Any]) -> str:
+    value = error.get("type", "Semgrep error")
+    if isinstance(value, list) and value:
+        return str(value[0])
+    return str(value)
+
+
+def report_finding(result: dict[str, Any]) -> None:
+    extra = result.get("extra", {})
+    severity = str(extra.get("severity", "WARNING")).upper()
+    level = "error" if severity == "ERROR" else "warning" if severity == "WARNING" else "notice"
+    start = result.get("start", {})
+    end = result.get("end", {})
+    annotation(
+        level,
+        str(extra.get("message", "Semgrep finding")),
+        file=result.get("path"),
+        line=start.get("line"),
+        col=start.get("col"),
+        endLine=end.get("line"),
+        endColumn=end.get("col"),
+        title=result.get("check_id", "Semgrep finding"),
+    )
+
+
+def report_error(error: dict[str, Any]) -> None:
+    spans = error.get("spans") or []
+    span = spans[0] if spans else {}
+    start = span.get("start", {})
+    end = span.get("end", {})
+    annotation(
+        "error",
+        str(error.get("message", "Semgrep analysis error")),
+        file=error.get("path") or span.get("file"),
+        line=start.get("line"),
+        col=start.get("col"),
+        endLine=end.get("line"),
+        endColumn=end.get("col"),
+        title=f"Semgrep {error_type(error)}",
+    )
+
+
+def write_summary(findings: int, errors: int, outcome: str) -> None:
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return
+
+    if errors:
+        status = f"Scan incomplete: {errors} analysis error(s); {findings} finding(s) in successfully parsed code."
+    elif outcome != "success":
+        status = f"Scan failed with {findings} finding(s) and no structured analysis errors."
+    else:
+        status = f"Scan complete: {findings} finding(s); no analysis errors."
+
+    with Path(summary_path).open("a", encoding="utf-8") as summary:
+        summary.write(f"## Semgrep\n\n{status}\n")
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} <semgrep.json>", file=sys.stderr)
+        return 2
+
+    output_path = Path(sys.argv[1])
+    if not output_path.is_file():
+        annotation("error", f"Semgrep did not create its JSON output at {output_path}", title="Semgrep scan failed")
+        return 1
+
+    try:
+        output = json.loads(output_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        annotation("error", f"Could not read Semgrep JSON output: {error}", title="Semgrep scan failed")
+        return 1
+
+    findings = output.get("results") or []
+    errors = output.get("errors") or []
+    outcome = os.environ.get("SEMGREP_OUTCOME", "success")
+
+    for finding in findings:
+        report_finding(finding)
+    for error in errors:
+        report_error(error)
+
+    if outcome != "success" and not findings and not errors:
+        annotation("error", "Semgrep exited unsuccessfully without a structured finding or error.", title="Semgrep scan failed")
+
+    write_summary(len(findings), len(errors), outcome)
+    return 1 if errors or outcome != "success" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_report_semgrep_results.py
+++ b/.github/scripts/test_report_semgrep_results.py
@@ -1,0 +1,87 @@
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("report-semgrep-results.py")
+
+
+class ReportSemgrepResultsTest(unittest.TestCase):
+    def run_report(self, output: dict, outcome: str = "success") -> subprocess.CompletedProcess[str]:
+        with tempfile.TemporaryDirectory() as directory:
+            output_path = Path(directory, "semgrep.json")
+            summary_path = Path(directory, "summary.md")
+            output_path.write_text(json.dumps(output), encoding="utf-8")
+            env = {**os.environ, "SEMGREP_OUTCOME": outcome, "GITHUB_STEP_SUMMARY": str(summary_path)}
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT), str(output_path)],
+                env=env,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            result.summary = summary_path.read_text(encoding="utf-8")
+            return result
+
+    def test_successful_clean_scan(self) -> None:
+        result = self.run_report({"results": [], "errors": []})
+
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "")
+        self.assertIn("Scan complete: 0 finding(s); no analysis errors.", result.summary)
+
+    def test_partial_parsing_is_annotated_and_fails(self) -> None:
+        result = self.run_report(
+            {
+                "results": [],
+                "errors": [
+                    {
+                        "type": ["PartialParsing", []],
+                        "message": "Syntax error\nwhile parsing",
+                        "path": ".github/workflows/release.yml",
+                        "spans": [
+                            {
+                                "file": ".github/workflows/release.yml",
+                                "start": {"line": 12, "col": 3},
+                                "end": {"line": 12, "col": 8},
+                            }
+                        ],
+                    }
+                ],
+            }
+        )
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("::error file=.github/workflows/release.yml,line=12,col=3", result.stdout)
+        self.assertIn("title=Semgrep PartialParsing::Syntax error%0Awhile parsing", result.stdout)
+        self.assertIn("Scan incomplete: 1 analysis error(s)", result.summary)
+
+    def test_blocking_finding_is_annotated_and_fails(self) -> None:
+        result = self.run_report(
+            {
+                "results": [
+                    {
+                        "check_id": "example.rule",
+                        "path": ".github/workflows/example.yml",
+                        "start": {"line": 4, "col": 1},
+                        "end": {"line": 4, "col": 9},
+                        "extra": {"severity": "ERROR", "message": "Unsafe command"},
+                    }
+                ],
+                "errors": [],
+            },
+            outcome="failure",
+        )
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("::error file=.github/workflows/example.yml,line=4,col=1", result.stdout)
+        self.assertIn("title=example.rule::Unsafe command", result.stdout)
+        self.assertIn("Scan failed with 1 finding(s)", result.summary)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -32,6 +32,7 @@ jobs:
                     --config "p/security-audit" \
                     --config "p/trailofbits" \
                     --config "p/github-actions" \
+                    --exclude ".semgrep/rules/*.test.yaml" \
                     --error \
                     --metrics=off \
                     --verbose \

--- a/.github/workflows/semgrep-tests.yml
+++ b/.github/workflows/semgrep-tests.yml
@@ -23,3 +23,7 @@ jobs:
             - name: Test custom Semgrep rules
               run: |
                   semgrep --test .semgrep/
+
+            - name: Test Semgrep result reporting
+              run: |
+                  python3 -m unittest discover .github/scripts -p 'test_*.py'

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -30,7 +30,9 @@ jobs:
               with:
                   repository: PostHog/.github
                   path: dotgithub-repo
-                  sparse-checkout: .semgrep
+                  sparse-checkout: |
+                      .semgrep
+                      .github/scripts
 
             - name: Check for .github directory
               id: check
@@ -40,8 +42,14 @@ jobs:
                   fi
 
             - name: Run Semgrep
+              id: semgrep
               if: steps.check.outputs.exists == 'true'
+              continue-on-error: true
               run: |
+                  # These upstream rules reparse every run block as Bash and reject valid GitHub expressions.
+                  # Local generic-parser replacements preserve their coverage. Remove both exclusions and the
+                  # replacements after https://github.com/semgrep/semgrep-rules/issues/3688 is fixed and the
+                  # compatibility fixture passes with p/github-actions under --strict.
                   semgrep \
                     --config "dotgithub-repo/.semgrep/rules/" \
                     --config "p/owasp-top-ten" \
@@ -53,7 +61,21 @@ jobs:
                     --exclude-rule trailofbits.generic.redis-unencrypted-transport.redis-unencrypted-transport \
                     --exclude-rule trailofbits.yaml.docker-compose.port-all-interfaces.port-all-interfaces \
                     --exclude-rule yaml.github-actions.security.audit.unsafe-add-mask-workflow-command.unsafe-add-mask-workflow-command \
+                    --exclude-rule yaml.github-actions.security.curl-eval.curl-eval \
+                    --exclude-rule yaml.github-actions.security.gha-curl-pipe-shell.gha-curl-pipe-shell \
                     --error \
+                    --strict \
+                    --json-output "$RUNNER_TEMP/semgrep.json" \
                     --metrics=off \
                     --verbose \
                     .github/
+
+            - name: Report Semgrep results
+              if: always() && steps.semgrep.outcome != 'skipped'
+              env:
+                  SEMGREP_OUTCOME: ${{ steps.semgrep.outcome }}
+              run: |
+                  python3 dotgithub-repo/.github/scripts/report-semgrep-results.py "$RUNNER_TEMP/semgrep.json"
+                  if [ "$SEMGREP_OUTCOME" != "success" ]; then
+                    exit 1
+                  fi

--- a/.semgrep/rules/github-actions-curl-shell.test.yaml
+++ b/.semgrep/rules/github-actions-curl-shell.test.yaml
@@ -43,3 +43,9 @@ jobs:
               run: |
                   SCRIPT=`curl --fail https://example.com/install.sh`
                   eval "$SCRIPT"
+
+            - name: Detect evaluated curl response with braced expansion
+              # ruleid: github-actions-curl-eval
+              run: |
+                  SCRIPT=$(curl --fail https://example.com/install.sh)
+                  eval "${SCRIPT}"

--- a/.semgrep/rules/github-actions-curl-shell.test.yaml
+++ b/.semgrep/rules/github-actions-curl-shell.test.yaml
@@ -1,0 +1,33 @@
+name: GitHub Actions curl shell checks
+
+on: push
+
+jobs:
+    test:
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                name: [one, two]
+        steps:
+            - name: Valid GitHub expression must parse without errors
+              run: echo "Running ${{ matrix.name }}"
+
+            - name: Safe curl usage
+              run: curl --fail --output tool.tar.gz https://example.com/tool.tar.gz
+
+            - name: Detect curl piped to Bash
+              # ruleid: github-actions-curl-pipe-shell
+              run: curl --fail https://example.com/install.sh | bash
+
+            - name: Detect wget piped to sh
+              # ruleid: github-actions-curl-pipe-shell
+              run: |
+                  wget -qO- https://example.com/install.sh |
+                    sh
+
+            - name: Detect evaluated curl response
+              # ruleid: github-actions-curl-eval
+              run: |
+                  SCRIPT=$(curl --fail https://example.com/install.sh)
+                  echo "${{ matrix.name }}"
+                  eval "$SCRIPT"

--- a/.semgrep/rules/github-actions-curl-shell.test.yaml
+++ b/.semgrep/rules/github-actions-curl-shell.test.yaml
@@ -31,3 +31,15 @@ jobs:
                   SCRIPT=$(curl --fail https://example.com/install.sh)
                   echo "${{ matrix.name }}"
                   eval "$SCRIPT"
+
+            - name: Detect evaluated quoted curl response
+              # ruleid: github-actions-curl-eval
+              run: |
+                  SCRIPT="$(curl --fail https://example.com/install.sh)"
+                  eval "$SCRIPT"
+
+            - name: Detect evaluated backtick curl response
+              # ruleid: github-actions-curl-eval
+              run: |
+                  SCRIPT=`curl --fail https://example.com/install.sh`
+                  eval "$SCRIPT"

--- a/.semgrep/rules/github-actions-curl-shell.yaml
+++ b/.semgrep/rules/github-actions-curl-shell.yaml
@@ -72,5 +72,5 @@ rules:
           - pattern: 'run: $SHELL'
           - metavariable-regex:
                 metavariable: $SHELL
-                regex: '(?s).*\b([A-Za-z_][A-Za-z0-9_]*)\s*=\s*\$\([^)]*\bcurl\b[^)]*\).*?\beval\b[^\n]*\$\1.*'
+                regex: '(?s).*\b([A-Za-z_][A-Za-z0-9_]*)\s*=\s*"?(?:\$\([^)]*\bcurl\b[^)]*\)|`[^`]*\bcurl\b[^`]*`)"?.*?\beval\b[^\n]*\$\1.*'
       severity: ERROR

--- a/.semgrep/rules/github-actions-curl-shell.yaml
+++ b/.semgrep/rules/github-actions-curl-shell.yaml
@@ -1,0 +1,76 @@
+# Compatibility replacements for the upstream curl-eval and
+# gha-curl-pipe-shell rules. The upstream rules parse every run block as Bash,
+# which raises PartialParsing for valid GitHub expressions such as ${{ ... }}.
+# Generic nested parsing keeps these checks active without rejecting expressions.
+# Remove this file when https://github.com/semgrep/semgrep-rules/issues/3688 is
+# fixed and the paired fixture passes against p/github-actions under --strict.
+rules:
+    - id: github-actions-curl-pipe-shell
+      languages:
+          - yaml
+      message: >-
+          A `run:` step pipes the output of `curl` or `wget` directly into a shell interpreter.
+          Download the file first, verify its checksum or signature, and then execute it.
+      metadata:
+          category: security
+          cwe:
+              - "CWE-78: Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')"
+          references:
+              - https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions
+              - https://www.idontplaydarts.com/2016/04/detecting-curl-pipe-bash-server-side/
+          technology:
+              - github-actions
+              - shell
+          subcategory:
+              - vuln
+          likelihood: MEDIUM
+          impact: HIGH
+          confidence: HIGH
+      patterns:
+          - pattern-inside: 'steps: [...]'
+          - pattern-inside: |
+                - run: ...
+                  ...
+          - pattern: 'run: $SHELL'
+          - metavariable-pattern:
+                language: generic
+                metavariable: $SHELL
+                patterns:
+                    - pattern-either:
+                          - pattern: curl ... | $CMD ...
+                          - pattern: wget ... | $CMD ...
+                    - metavariable-regex:
+                          metavariable: $CMD
+                          regex: '^(bash|sh|python3?|ruby|perl)$'
+      severity: ERROR
+
+    - id: github-actions-curl-eval
+      languages:
+          - yaml
+      message: >-
+          Data returned by `curl` is passed to `eval`. Avoid evaluating remote data. If this is
+          unavoidable, verify the downloaded content's checksum or signature first.
+      metadata:
+          category: security
+          cwe:
+              - "CWE-78: Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')"
+          references:
+              - https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions
+          technology:
+              - github-actions
+              - shell
+          subcategory:
+              - audit
+          likelihood: LOW
+          impact: HIGH
+          confidence: LOW
+      patterns:
+          - pattern-inside: 'steps: [...]'
+          - pattern-inside: |
+                - run: ...
+                  ...
+          - pattern: 'run: $SHELL'
+          - metavariable-regex:
+                metavariable: $SHELL
+                regex: '(?s).*\b([A-Za-z_][A-Za-z0-9_]*)\s*=\s*\$\([^)]*\bcurl\b[^)]*\).*?\beval\b[^\n]*\$\1.*'
+      severity: ERROR

--- a/.semgrep/rules/github-actions-curl-shell.yaml
+++ b/.semgrep/rules/github-actions-curl-shell.yaml
@@ -72,5 +72,5 @@ rules:
           - pattern: 'run: $SHELL'
           - metavariable-regex:
                 metavariable: $SHELL
-                regex: '(?s).*\b([A-Za-z_][A-Za-z0-9_]*)\s*=\s*"?(?:\$\([^)]*\bcurl\b[^)]*\)|`[^`]*\bcurl\b[^`]*`)"?.*?\beval\b[^\n]*\$\1.*'
+                regex: '(?s).*\b([A-Za-z_][A-Za-z0-9_]*)\s*=\s*"?(?:\$\([^)]*\bcurl\b[^)]*\)|`[^`]*\bcurl\b[^`]*`)"?.*?\beval\b[^\n]*\$(?:\1|\{\1\}).*'
       severity: ERROR

--- a/.semgrep/rules/github-actions-pull-request-target.yaml
+++ b/.semgrep/rules/github-actions-pull-request-target.yaml
@@ -46,8 +46,8 @@ rules:
           confidence: HIGH
       paths:
           include:
-              - '*.github/workflows/*.yml'
-              - '*.github/workflows/*.yaml'
+              - '/.github/workflows/*.yml'
+              - '/.github/workflows/*.yaml'
       patterns:
           - pattern-either:
                 # Mapping form (with or without sibling triggers, with or without sub-config):


### PR DESCRIPTION
## Problem

The org-wide Semgrep workflow could report zero findings while partially parsing GitHub Actions workflows. The upstream `curl-eval` and `gha-curl-pipe-shell` rules reparse valid `${{ ... }}` expressions as Bash, but `--error` did not fail the scan for those parser warnings.

## Changes

- run Semgrep with `--strict` and structured JSON output
- annotate findings and analysis errors, publish an accurate job summary, and fail closed on partial/internal errors
- temporarily exclude the two incompatible upstream rules while preserving their coverage with tested generic-parser replacements
- document that the exclusions are removed after semgrep/semgrep-rules#3688 is fixed and the strict compatibility fixture passes
- update custom workflow include patterns for Semgrepignore v2 compatibility
- exclude intentional Semgrep `.test.yaml` fixtures from the repository-wide security scan; they remain covered by `semgrep --test`

## Testing

- `semgrep --test .semgrep/` — 4/4 passed
- `python3 -m unittest discover .github/scripts -p 'test_*.py'` — 3/3 passed
- `actionlint` on all changed workflows
- repository-wide security scan matching `ci-security.yml`: 100% parsed, 0 errors, 0 findings
- full scan of `PostHog/posthog-js/.github`: 100% parsed, 0 errors, 0 findings
- full scan of `PostHog/.github/.github`: 100% parsed, 0 errors, 0 findings