### PR TITLE
ci: declare timeout-minutes on every job

### DIFF
--- a/.github/workflows/changeset-hygiene.yml
+++ b/.github/workflows/changeset-hygiene.yml
@@ -17,6 +17,7 @@ jobs:
     check:
         name: Check changeset hygiene
         runs-on: ubuntu-latest
+        timeout-minutes: 10
         steps:
             - name: Checkout caller repository
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -17,6 +17,7 @@ jobs:
     # scans GitHub Actions and other repo-wide config
     semgrep-local:
         runs-on: ubuntu-latest
+        timeout-minutes: 20
         container:
             image: semgrep/semgrep
 

--- a/.github/workflows/flags-project-board.yml
+++ b/.github/workflows/flags-project-board.yml
@@ -68,6 +68,7 @@ on:
 jobs:
     add-to-project-board:
         runs-on: ubuntu-latest
+        timeout-minutes: 5
         # When the workflow is called via `workflow_call` (aka from another workflow via the uses: keyword), from another repository,
         # the github.event_name is supposed to be `workflow_call`, but because this workflow lives in the special `.github` repository,
         # it preserves the original event name (e.g. pull_request).

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -11,6 +11,7 @@ jobs:
     lint-pr:
         name: Validate PR title against Conventional Commits
         runs-on: ubuntu-latest
+        timeout-minutes: 5
         permissions:
           pull-requests: read
         steps:

--- a/.github/workflows/notify-approval-needed.yml
+++ b/.github/workflows/notify-approval-needed.yml
@@ -37,6 +37,7 @@ on:
 jobs:
   notify:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       slack_ts: ${{ steps.notify.outputs.ts }}
     steps:

--- a/.github/workflows/semgrep-package-managers.yml
+++ b/.github/workflows/semgrep-package-managers.yml
@@ -18,6 +18,7 @@ jobs:
         # (free minutes, and not every public repo has Depot enabled). The repository
         # context reflects the target repo, so this resolves per-repo automatically.
         runs-on: ${{ github.event.repository.private && 'depot-ubuntu-latest' || 'ubuntu-latest' }}
+        timeout-minutes: 15
         container:
             image: semgrep/semgrep:1.163.0@sha256:7cad2bc2d1e44f87f0bf4be6d1fa23aa90fb72015bebc89fb91385d813987a03
 

--- a/.github/workflows/semgrep-tests.yml
+++ b/.github/workflows/semgrep-tests.yml
@@ -13,6 +13,7 @@ env:
 jobs:
     semgrep-test-rules:
         runs-on: ubuntu-latest
+        timeout-minutes: 10
         container:
             image: semgrep/semgrep:1.163.0@sha256:7cad2bc2d1e44f87f0bf4be6d1fa23aa90fb72015bebc89fb91385d813987a03
 

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -18,6 +18,7 @@ jobs:
         # (free minutes, and not every public repo has Depot enabled). The repository
         # context reflects the target repo, so this resolves per-repo automatically.
         runs-on: ${{ github.event.repository.private && 'depot-ubuntu-latest' || 'ubuntu-latest' }}
+        timeout-minutes: 15
         container:
             image: semgrep/semgrep:1.163.0@sha256:7cad2bc2d1e44f87f0bf4be6d1fa23aa90fb72015bebc89fb91385d813987a03
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@ Each rule has a paired `.test.yaml` fixture — update it when you touch a rule.
 - **No shell injection.** Never interpolate `${{ steps.*.outputs.* }}` or other untrusted values into a `run:`/`script:` block. Route through an `env:` var and reference `"$VAR"` double-quoted. The custom `github-actions-shell-injection` rule enforces this.
 - **`pull_request_target` is effectively banned** (`github-actions-pull-request-target` rule errors on it). If truly required: don't check out the PR head, scope `permissions:` minimally, and add a justified `# nosemgrep:` line reviewed by security.
 - Set explicit least-privilege `permissions:` on every workflow/job.
+- **Declare `timeout-minutes` on every job.** Without it a job inherits GitHub's 360-minute default, and a network hang then burns a runner for six hours before anything kills it — multiplied by every repo in the org, since these run as required workflows. Set a generous multiple of the job's normal runtime, not a tight bound.
 
 ## Keeping this file current
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ Each rule has a paired `.test.yaml` fixture — update it when you touch a rule.
 - **No shell injection.** Never interpolate `${{ steps.*.outputs.* }}` or other untrusted values into a `run:`/`script:` block. Route through an `env:` var and reference `"$VAR"` double-quoted. The custom `github-actions-shell-injection` rule enforces this.
 - **`pull_request_target` is effectively banned** (`github-actions-pull-request-target` rule errors on it). If truly required: don't check out the PR head, scope `permissions:` minimally, and add a justified `# nosemgrep:` line reviewed by security.
 - Set explicit least-privilege `permissions:` on every workflow/job.
-- **Declare `timeout-minutes` on every job.** Without it a job inherits GitHub's 360-minute default, and a network hang then burns a runner for six hours before anything kills it — multiplied by every repo in the org, since these run as required workflows. Set a generous multiple of the job's normal runtime, not a tight bound.
+- **Declare `timeout-minutes` on every job.** The GitHub default is 360 minutes, so a hung job holds a runner for six hours before anything kills it. Set a generous multiple of the job's normal runtime, not a tight bound.
 
 ## Keeping this file current
 


### PR DESCRIPTION
## Problem

**8 of the 10 jobs here declare no `timeout-minutes`**, so they inherit GitHub's 360-minute default. That ceiling is the only thing that stopped a real hang:

> `semgrep-package-managers` ran **6h 0m 3s** — started `06:19:04`, killed `12:19:07` — on [PostHog/posthog#73960](https://github.com/PostHog/posthog/pull/73960).
> Evidence: [job log](https://github.com/PostHog/posthog/actions/runs/30334400283/job/90196102869) · [run](https://github.com/PostHog/posthog/actions/runs/30334400283) (`conclusion: cancelled`)

That job's normal runtime, across 72 distinct runs sampled from the Actions API:

| | |
|---|---|
| 71 healthy runs | median **0.87 min**, p95 **1.22 min**, slowest **1.30 min** |
| the three slowest of those | [1.30m](https://github.com/PostHog/posthog/actions/runs/30363760958) · [1.30m](https://github.com/PostHog/posthog/actions/runs/30364002769) · [1.25m](https://github.com/PostHog/posthog/actions/runs/30365047497) |
| 1 outlier | **360.05 min** (above) |
| healthy runs exceeding the 15 min bound this PR sets | **0** — none exceeds 1.5 min |

It runs [org-wide as a required workflow](https://github.com/PostHog/.github/blob/bd5da77/.github/workflows/semgrep-package-managers.yml#L16-L18), so one hang is one stuck runner **per repo**. Likely cause: it [fetches all seven rules from the semgrep registry](https://github.com/PostHog/.github/blob/bd5da77/.github/workflows/semgrep-package-managers.yml#L33-L39) over the network.

The monorepo already mandates this — [`CLAUDE.md` L116](https://github.com/PostHog/posthog/blob/1a14a1c184d3a8ed2b021c1be68a9a9e2e65e2c5/CLAUDE.md#L116): *"Every job in `.github/workflows/` must declare `timeout-minutes`"*. That rule can't reach across repos, which is why this went unnoticed.

## Changes

`timeout-minutes` on the 8 unbounded jobs. Generous multiples of observed runtime — the goal is to cap a hang, not fail a healthy job.

| workflow | job | timeout |
|---|---|---|
| [`ci-security.yml`](https://github.com/PostHog/.github/blob/bd5da77/.github/workflows/ci-security.yml#L19) | `semgrep-local` | 20 |
| [`semgrep.yml`](https://github.com/PostHog/.github/blob/bd5da77/.github/workflows/semgrep.yml#L20) | `semgrep` | 15 |
| [`semgrep-package-managers.yml`](https://github.com/PostHog/.github/blob/bd5da77/.github/workflows/semgrep-package-managers.yml#L20) | `semgrep-package-managers` | 15 |
| [`semgrep-tests.yml`](https://github.com/PostHog/.github/blob/bd5da77/.github/workflows/semgrep-tests.yml#L15) | `semgrep-test-rules` | 10 |
| [`changeset-hygiene.yml`](https://github.com/PostHog/.github/blob/bd5da77/.github/workflows/changeset-hygiene.yml#L19) | `check` | 10 |
| [`notify-approval-needed.yml`](https://github.com/PostHog/.github/blob/bd5da77/.github/workflows/notify-approval-needed.yml#L39) | `notify` | 10 |
| [`lint-pr.yml`](https://github.com/PostHog/.github/blob/bd5da77/.github/workflows/lint-pr.yml#L13) | `lint-pr` | 5 |
| [`flags-project-board.yml`](https://github.com/PostHog/.github/blob/bd5da77/.github/workflows/flags-project-board.yml#L70) | `add-to-project-board` | 5 |

The two semgrep scan bounds mirror the monorepo's equivalents: [`semgrep-general` 20](https://github.com/PostHog/posthog/blob/1a14a1c184d3a8ed2b021c1be68a9a9e2e65e2c5/.github/workflows/ci-security.yaml#L277), [`semgrep-test-rules` 10](https://github.com/PostHog/posthog/blob/1a14a1c184d3a8ed2b021c1be68a9a9e2e65e2c5/.github/workflows/ci-security.yaml#L386).

Untouched: [`detect-markdown-only.yml`](https://github.com/PostHog/.github/blob/bd5da77/.github/workflows/detect-markdown-only.yml#L14) and [`semantic-pr-title.yml`](https://github.com/PostHog/.github/blob/bd5da77/.github/workflows/semantic-pr-title.yml#L10), which already declare 5.

`AGENTS.md` lists this repo's enforced workflow conventions but not this one, so it gets a line, per its own *"keeping this file current"* instruction. (`CLAUDE.md` is a symlink to it.)

## Deliberately not in this PR

- **[`ci-security.yml` pins `image: semgrep/semgrep`](https://github.com/PostHog/.github/blob/bd5da77/.github/workflows/ci-security.yml#L21)** — no tag, no digest — while its three siblings pin [`1.163.0` by digest](https://github.com/PostHog/.github/blob/bd5da77/.github/workflows/semgrep-package-managers.yml#L22). Floating tags are how [PostHog/posthog#59428](https://github.com/PostHog/posthog/pull/59428) and [#65921](https://github.com/PostHog/posthog/pull/65921) got bitten.
- **No job here passes semgrep's own `--timeout`.** [PostHog/posthog#65921](https://github.com/PostHog/posthog/pull/65921) added it in the monorepo to bound a rule-validation hang, where it's now [used on every scan](https://github.com/PostHog/posthog/blob/1a14a1c184d3a8ed2b021c1be68a9a9e2e65e2c5/.github/workflows/ci-security.yaml#L115). It would catch this class of failure sooner and more precisely than a job ceiling.

Happy to follow up on either.

## Testing

Parsed all 10 workflows and asserted every job resolves a `timeout-minutes` and no existing value changed. 9 single-line insertions; indentation is per-file (`notify-approval-needed.yml` is 2-space, the rest 4-space), and the `CLAUDE.md` symlink survived the `AGENTS.md` edit. No workflow logic, `permissions:`, action pins, or semgrep rules touched, so `semgrep --test .semgrep/` is unaffected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Found by Claude (Claude Code) while auditing CI cost on the monorepo — a 360-minute outlier against a 0.87-minute median. Tracing it here took a moment, because the Actions API reports these runs with a local-looking `path` even though the workflow lives in this repo.
