### PR TITLE
feat(semgrep): flag container images not pinned to a digest

### DIFF
--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -19,7 +19,7 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 20
         container:
-            image: semgrep/semgrep
+            image: semgrep/semgrep:1.163.0@sha256:7cad2bc2d1e44f87f0bf4be6d1fa23aa90fb72015bebc89fb91385d813987a03
 
         steps:
             - name: Checkout

--- a/.semgrep/rules/github-actions-unpinned-image.test.yaml
+++ b/.semgrep/rules/github-actions-unpinned-image.test.yaml
@@ -1,0 +1,290 @@
+# container.image with no tag at all (resolves to :latest)
+on: push
+
+name: container image untagged
+
+jobs:
+    test:
+        runs-on: ubuntu-latest
+        container:
+            # ruleid: github-actions-unpinned-image
+            image: semgrep/semgrep
+        steps:
+            - run: echo hi
+---
+# container.image pinned to a tag only — tags are mutable
+on: push
+
+name: container image tag only
+
+jobs:
+    test:
+        runs-on: ubuntu-latest
+        container:
+            # ruleid: github-actions-unpinned-image
+            image: semgrep/semgrep:1.163.0
+            options: --cpus 1
+        steps:
+            - run: echo hi
+---
+# container.image pinned to :latest
+on: push
+
+name: container image latest
+
+jobs:
+    test:
+        runs-on: ubuntu-latest
+        container:
+            # ruleid: github-actions-unpinned-image
+            image: node:latest
+        steps:
+            - run: echo hi
+---
+# container.image quoted
+on: push
+
+name: container image quoted
+
+jobs:
+    test:
+        runs-on: ubuntu-latest
+        container:
+            # ruleid: github-actions-unpinned-image
+            image: 'ghcr.io/posthog/example:v1'
+        steps:
+            - run: echo hi
+---
+# container string shorthand
+on: push
+
+name: container shorthand
+
+jobs:
+    test:
+        runs-on: ubuntu-latest
+        # ruleid: github-actions-unpinned-image
+        container: node:18-alpine
+        steps:
+            - run: echo hi
+---
+# services.<id>.image
+on: push
+
+name: services image
+
+jobs:
+    test:
+        runs-on: ubuntu-latest
+        services:
+            redis:
+                # ruleid: github-actions-unpinned-image
+                image: redis:7
+            postgres:
+                # ruleid: github-actions-unpinned-image
+                image: postgres:16
+                env:
+                    POSTGRES_PASSWORD: postgres
+        steps:
+            - run: echo hi
+---
+# docker:// step reference with a tag
+on: push
+
+name: docker uses tag
+
+jobs:
+    test:
+        runs-on: ubuntu-latest
+        steps:
+            # ruleid: github-actions-unpinned-image
+            - uses: docker://alpine:3.20
+---
+# docker:// step reference with no tag
+on: push
+
+name: docker uses untagged
+
+jobs:
+    test:
+        runs-on: ubuntu-latest
+        steps:
+            # ruleid: github-actions-unpinned-image
+            - uses: docker://ghcr.io/posthog/example
+---
+# Docker container action referencing a registry image
+name: docker container action
+
+runs:
+    using: docker
+    # ruleid: github-actions-unpinned-image
+    image: docker://alpine:3.20
+---
+# Negative: container.image pinned to a digest
+on: push
+
+name: container image digest pinned
+
+jobs:
+    test:
+        runs-on: ubuntu-latest
+        container:
+            # ok: github-actions-unpinned-image
+            image: semgrep/semgrep:1.163.0@sha256:7cad2bc2d1e44f87f0bf4be6d1fa23aa90fb72015bebc89fb91385d813987a03
+        steps:
+            - run: echo hi
+---
+# Negative: container.image digest without a tag is still immutable
+on: push
+
+name: container image bare digest
+
+jobs:
+    test:
+        runs-on: ubuntu-latest
+        container:
+            # ok: github-actions-unpinned-image
+            image: semgrep/semgrep@sha256:7cad2bc2d1e44f87f0bf4be6d1fa23aa90fb72015bebc89fb91385d813987a03
+        steps:
+            - run: echo hi
+---
+# Negative: container string shorthand pinned to a digest
+on: push
+
+name: container shorthand digest pinned
+
+jobs:
+    test:
+        runs-on: ubuntu-latest
+        # ok: github-actions-unpinned-image
+        container: node:18-alpine@sha256:7cad2bc2d1e44f87f0bf4be6d1fa23aa90fb72015bebc89fb91385d813987a03
+        steps:
+            - run: echo hi
+---
+# Negative: services images pinned to a digest
+on: push
+
+name: services image digest pinned
+
+jobs:
+    test:
+        runs-on: ubuntu-latest
+        services:
+            redis:
+                # ok: github-actions-unpinned-image
+                image: redis:7@sha256:7cad2bc2d1e44f87f0bf4be6d1fa23aa90fb72015bebc89fb91385d813987a03
+        steps:
+            - run: echo hi
+---
+# Negative: docker:// reference pinned to a digest
+on: push
+
+name: docker uses digest pinned
+
+jobs:
+    test:
+        runs-on: ubuntu-latest
+        steps:
+            # ok: github-actions-unpinned-image
+            - uses: docker://alpine@sha256:7cad2bc2d1e44f87f0bf4be6d1fa23aa90fb72015bebc89fb91385d813987a03
+---
+# Negative: ordinary action references are covered by the SHA-pinning rules, not this one
+on: push
+
+name: action references
+
+jobs:
+    test:
+        runs-on: ubuntu-latest
+        steps:
+            # ok: github-actions-unpinned-image
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+            # ok: github-actions-unpinned-image
+            - uses: ./.github/actions/slack-thread-reply
+---
+# Negative: `image` as an action input, not a job container
+on: push
+
+name: image as action input
+
+jobs:
+    test:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: docker/build-push-action@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.18.0
+              with:
+                  # ok: github-actions-unpinned-image
+                  image: ghcr.io/posthog/example:latest
+---
+# Negative: a Docker action that builds from a local Dockerfile pins nothing remote
+name: dockerfile action
+
+runs:
+    using: docker
+    # ok: github-actions-unpinned-image
+    image: Dockerfile
+---
+# Negative: the image is supplied by the caller, which is where the pin belongs
+on:
+    workflow_call:
+        inputs:
+            container-image:
+                type: string
+                required: true
+
+name: caller supplied image
+
+jobs:
+    test:
+        runs-on: ubuntu-latest
+        container:
+            # ok: github-actions-unpinned-image
+            image: ${{ inputs.container-image }}
+        services:
+            # Same exclusion without the surrounding whitespace, so that the two
+            # spellings of an expression behave identically.
+            redis:
+                # ok: github-actions-unpinned-image
+                image: ghcr.io/posthog/redis:${{inputs.tag}}
+        steps:
+            - run: echo hi
+---
+# Negative: `container` as an action input, not a job container
+on: push
+
+name: container as action input
+
+jobs:
+    test:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: azure/cli@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v2.1.0
+              with:
+                  # ok: github-actions-unpinned-image
+                  container: my-app-container
+---
+# Negative: `container` as an env var name
+on: push
+
+name: container as env var
+
+jobs:
+    test:
+        runs-on: ubuntu-latest
+        env:
+            # ok: github-actions-unpinned-image
+            container: some-value:v1
+        steps:
+            - run: echo hi
+---
+# Negative: image references inside a run block are not job containers
+on: push
+
+name: image name in run block
+
+jobs:
+    test:
+        runs-on: ubuntu-latest
+        steps:
+            # ok: github-actions-unpinned-image
+            - run: docker run --rm alpine:3.20 echo hi

--- a/.semgrep/rules/github-actions-unpinned-image.yaml
+++ b/.semgrep/rules/github-actions-unpinned-image.yaml
@@ -1,0 +1,107 @@
+# Flags container images in GitHub Actions that are not pinned to a digest.
+#
+# GitHub's "require actions to be pinned to a full-length commit SHA" policy
+# covers `uses:` action references only. It explicitly does not cover registry
+# images — see the "Docker Hub and GitHub Packages Container registry URLs are
+# currently not supported" note in the secure-use reference. So `container:`,
+# `services:`, and `docker://` references have no platform-level enforcement
+# and need a lint rule instead.
+#
+# Tags are mutable: whoever controls the repository (or anyone who compromises
+# their registry credentials) can repoint `semgrep/semgrep:1.163.0` at a new
+# manifest, and every job that pulls it executes the new code with whatever
+# secrets and permissions the workflow holds. A `@sha256:` digest is content
+# addressed and cannot be repointed.
+#
+# Pin with `name:tag@sha256:<digest>` — keep the tag for readability, the digest
+# is what's enforced. Resolve one with:
+#
+#     docker buildx imagetools inspect semgrep/semgrep:1.163.0 --format '{{.Manifest.Digest}}'
+#
+# A `${{ ... }}` value is not flagged: the image is chosen by the caller, so the
+# pin belongs at the call site. Nor is `image: Dockerfile` in a Docker action,
+# which builds locally rather than pulling.
+rules:
+    - id: github-actions-unpinned-image
+      languages:
+          - yaml
+      severity: ERROR
+      message: >-
+          Container image is not pinned to a `@sha256:` digest. Tags are mutable, so the image this
+          job pulls can be replaced after review with code that runs against the workflow's secrets
+          and permissions. Pin to `name:tag@sha256:<digest>`, resolving the digest with
+          `docker buildx imagetools inspect <name>:<tag> --format '{{.Manifest.Digest}}'`. GitHub's
+          SHA-pinning policy does not cover registry images, so this is the only enforcement.
+      metadata:
+          category: security
+          cwe:
+              - "CWE-1357: Reliance on Insufficiently Trustworthy Component"
+          owasp:
+              - A08:2021 - Software and Data Integrity Failures
+          references:
+              - https://docs.github.com/en/actions/reference/security/secure-use
+              - https://docs.github.com/en/actions/using-jobs/running-jobs-in-a-container
+              - https://slsa.dev/spec/v1.0/threats#e-compromise-package-repo
+          technology:
+              - github-actions
+              - docker
+          subcategory:
+              - audit
+          likelihood: MEDIUM
+          impact: HIGH
+          confidence: HIGH
+      paths:
+          include:
+              - '/.github/workflows/*.yml'
+              - '/.github/workflows/*.yaml'
+              - 'action.yml'
+              - 'action.yaml'
+      pattern-either:
+          # jobs.<id>.container.image
+          - patterns:
+                - pattern-inside: |
+                      container:
+                        ...
+                - pattern: 'image: $IMG'
+                - metavariable-regex:
+                      metavariable: $IMG
+                      regex: '^["'']?(?!.*\$\{\{)(?![^"''\s]*@sha256:[0-9a-fA-F]{64})[^"''\s]+["'']?$'
+          # jobs.<id>.services.<id>.image
+          - patterns:
+                - pattern-inside: |
+                      services:
+                        ...
+                - pattern: 'image: $IMG'
+                - metavariable-regex:
+                      metavariable: $IMG
+                      regex: '^["'']?(?!.*\$\{\{)(?![^"''\s]*@sha256:[0-9a-fA-F]{64})[^"''\s]+["'']?$'
+          # jobs.<id>.container string shorthand. A sibling `runs-on:` is what
+          # makes this a job definition rather than an action input or an env
+          # var that happens to be named `container`, both of which are common
+          # enough to matter. The metavariable-regex then rejects the mapping
+          # form, whose $IMG binds to a block rather than to an image ref.
+          - patterns:
+                - pattern-either:
+                      - pattern: |
+                            runs-on: ...
+                            ...
+                            container: $IMG
+                      - pattern: |
+                            container: $IMG
+                            ...
+                            runs-on: ...
+                - focus-metavariable: $IMG
+                - metavariable-regex:
+                      metavariable: $IMG
+                      regex: '^["'']?(?!.*\$\{\{)(?![^"''\s]*@sha256:[0-9a-fA-F]{64})[^"''\s]+["'']?$'
+          # `uses: docker://...` steps, and `runs.image` in a Docker container
+          # action. Both name a registry image rather than an action repo, so
+          # neither is covered by the SHA-pinning policy or by the rules that
+          # enforce it for `uses:`.
+          - patterns:
+                - pattern-either:
+                      - pattern: 'uses: $IMG'
+                      - pattern: 'image: $IMG'
+                - metavariable-regex:
+                      metavariable: $IMG
+                      regex: '^["'']?docker://(?![^"''\s]*@sha256:[0-9a-fA-F]{64})'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ Each rule has a paired `.test.yaml` fixture — update it when you touch a rule.
 ## Conventions (enforced, match them)
 
 - **Pin every action to a full commit SHA** with a trailing `# vX.Y.Z` comment — third-party *and* first-party `PostHog/*`.
+- **Pin every container image to a digest** — `name:tag@sha256:<digest>` for `container:`, `services:`, and `docker://` refs. GitHub's SHA-pinning policy covers `uses:` action refs only and explicitly excludes registry images, so the custom `github-actions-unpinned-image` rule is the only enforcement. Resolve a digest with `docker buildx imagetools inspect <name>:<tag> --format '{{.Manifest.Digest}}'`.
 - **No shell injection.** Never interpolate `${{ steps.*.outputs.* }}` or other untrusted values into a `run:`/`script:` block. Route through an `env:` var and reference `"$VAR"` double-quoted. The custom `github-actions-shell-injection` rule enforces this.
 - **`pull_request_target` is effectively banned** (`github-actions-pull-request-target` rule errors on it). If truly required: don't check out the PR head, scope `permissions:` minimally, and add a justified `# nosemgrep:` line reviewed by security.
 - Set explicit least-privilege `permissions:` on every workflow/job.


### PR DESCRIPTION
## What

Adds `github-actions-unpinned-image`, which errors on container images that aren't pinned to a `@sha256:` digest. Four surfaces:

| Surface | Matched via |
|---|---|
| `jobs.<id>.container.image` | `pattern-inside: container:` |
| `jobs.<id>.services.<id>.image` | `pattern-inside: services:` |
| `container: <ref>` string shorthand | sibling `runs-on:` required |
| `uses: docker://…` and `runs.image: docker://…` | `docker://` prefix |

`paths.include` covers `.github/workflows/*.{yml,yaml}` plus `action.{yml,yaml}`, so Docker container actions are in scope too.

## Why

GitHub shipped a [SHA-pinning policy](https://github.blog/changelog/2025-08-15-github-actions-policy-now-supports-blocking-and-sha-pinning-actions/) in Aug 2025, but it covers `uses:` action references only. The [secure-use reference](https://docs.github.com/en/actions/reference/security/secure-use) is explicit:

> Docker Hub and GitHub Packages Container registry URLs are currently not supported. For example, references to Docker container actions using `docker://` syntax aren't supported.

Nothing in the policy touches `container.image` or `services`. So registry images have no platform-level enforcement, and a lint rule is the only way to hold the same line we already hold for actions.

Tags are mutable. Whoever controls an image — or whoever compromises their registry credentials — can repoint `semgrep/semgrep:1.163.0` at a new manifest after review, and every job that pulls it runs the new code against that workflow's secrets and permissions. A digest is content-addressed and can't be repointed.

## Verification

- `semgrep --test .semgrep/` → 5/5. Reported lines match all 10 `ruleid` annotations exactly, no extras.
- `semgrep --validate` → 0 config errors.
- Reproduced the `semgrep.yml` invocation shape (rules loaded from `dotgithub-repo/`, target `.github/`, caller as a real git repo) against a caller-repo skeleton — all four surfaces fire.

Two false positives surfaced during development and are now regression fixtures: `with: container: my-app-container` (action input) and `env: container: foo` both matched the shorthand branch. Requiring a sibling `runs-on:` fixed it.

## Rollout — please read before approving

`.semgrep/rules/` is loaded at runtime by `semgrep.yml`, so callers don't re-pin to pick this up. **The moment this merges, every org repo with an unpinned `container:`/`services:` image starts failing CI on its next run.**

Severity won't soften that. `--error` exits nonzero on any finding regardless of severity and `report-semgrep-results.py` propagates it, so shipping at `WARNING` fails identically — it is not a soft launch. Real options are landing as-is, surveying org repos and fixing them first, or landing behind an `--exclude-rule` until they're clean.

Draft pending that call.

## Known gap

`image: ${{ … }}` is not flagged, in either spelling. The image is chosen by the caller, so the pin belongs at the call site and this rule can't see there. It's also an evasion path — noted in the rule header.

## Not included

This repo's own `ci-security.yml` still runs `image: semgrep/semgrep` unpinned, which is what prompted the rule. Left out deliberately; it's a separate one-liner.

It *will* be caught once this merges. `ci-security.yml` loads only the `p/*` registry configs, but `semgrep.yml` also carries `on: pull_request` and runs on this repo's own PRs, loading `.semgrep/rules/` from `main`. So the next PR here fails on `ci-security.yml:22` until that pin lands.
